### PR TITLE
Add Some Improvements on Documentation Page

### DIFF
--- a/docusaurus/website/core/Footer.js
+++ b/docusaurus/website/core/Footer.js
@@ -25,7 +25,6 @@ class Footer extends React.Component {
     }
 
     render() {
-        const currentYear = new Date().getFullYear();
         return (
             <footer className="nav-footer" id="footer">
                 <a

--- a/docusaurus/website/siteConfig.js
+++ b/docusaurus/website/siteConfig.js
@@ -68,7 +68,7 @@ const siteConfig = {
   },*/
 
     // This copyright info is used in /core/Footer.js and blog rss/atom feeds.
-    copyright: "Copyright © " + new Date().getFullYear() + " Tokopedia OSS",
+    copyright: "Copyright © " + new Date().getUTCFullYear() + " Tokopedia OSS",
 
     highlight: {
         // Highlight.js theme to use for syntax highlighting in code blocks

--- a/docusaurus/website/static/css/custom.css
+++ b/docusaurus/website/static/css/custom.css
@@ -119,12 +119,13 @@
     margin: 0 auto;
     text-align: center;
     opacity: 0.5;
+    width: 60%;
+    max-width: 300px;
 }
 
 .tkpdOpenSourceLogo {
     position: relative;
-    width: 60%;
-    max-width: 300px;
+    width: 100%;
 }
 
 .docMainWrapper .mainContainer .postHeaderTitle {


### PR DESCRIPTION
Hi, I just already added a little bit improvement on docs website especially for Footer component:

1. As shown in the image below, users can click and redirect to [other page](https://github.com/tokopedia/) in the area marked as a red border. I think this is not quite good enough for user experience. Instead, users can be redirected if only they click on the Tokopedia logo. 

<img width="1425" alt="screen shot 2019-01-09 at 11 05 35" src="https://user-images.githubusercontent.com/43945767/50876609-92629300-1400-11e9-8efe-1d2017e36947.png">

2. Changed `getFullYear()` to `getUTCFullYear()` for copyrights date. This is because somehow in the [doc page](https://tokopedia.github.io/treats/) the date shows 2018 instead of 2019. I'm not sure this is good workaround since those API is getting date data in local machine/server, so I open to other suggestions. 
