### PR TITLE
Remove Development Host Check

### DIFF
--- a/packages/treats/scripts/config/webpack.config.client.development.js
+++ b/packages/treats/scripts/config/webpack.config.client.development.js
@@ -265,7 +265,8 @@ module.exports = ({
                 "Access-Control-Allow-Origin": "*"
             },
             stats: { colors: true, children: false },
-            overlay: true
+            overlay: true,
+            disableHostCheck: true
         },
         output: {
             path: path.join(__dirname, assetsOutputPath),


### PR DESCRIPTION
Hello, I'm adding this configuration rules for development server. I'm adding this because got the `Invalid Host Header` when change host to `dev.tokopedia.com` which it needed to avoid `cross-origin` while hitting the gqlserver (staging).