### PR TITLE
fix(build): fix default condition for build target

### DIFF
--- a/packages/treats/scripts/build
+++ b/packages/treats/scripts/build
@@ -89,7 +89,7 @@ const build = argv => {
                     webpackBuild(webpackConfig.client);
                     break;
                 default:
-                    if(argv.target) {
+                    if(!argv.target) {
                         webpackBuild(configs);
                     } else {
                         logger("warn", "Target unknown, can't build!");


### PR DESCRIPTION
Fix the default condition when developer run `build` command without specifying target build