### PR TITLE
build(package.json): upgrade react-router-dom to 5.0.0

### DIFF
--- a/packages/treats/package.json
+++ b/packages/treats/package.json
@@ -110,7 +110,7 @@
         "react-hot-loader": "4.3.11",
         "react-intl": "2.7.2",
         "react-redux": "5.1.0",
-        "react-router-dom": "4.3.1",
+        "react-router-dom": "5.0.0",
         "react-universal-component": "3.0.3",
         "redux": "4.0.1",
         "redux-devtools-extension": "2.13.5",


### PR DESCRIPTION
Following this issue that happens on react-router-dom 
https://github.com/ReactTraining/react-router/issues/6630

Fix: By upgrading the react-router-dom version to 5.0.0 
https://github.com/ReactTraining/react-router/issues/6630#issuecomment-473973090