### PR TITLE
feat(scripts/start): add on-demand modules build when start

### DIFF
--- a/packages/create-treats-app/generator/create-treats-app/<%APP_NAME%>/.gitignore
+++ b/packages/create-treats-app/generator/create-treats-app/<%APP_NAME%>/.gitignore
@@ -13,3 +13,5 @@ profile
 packages/**/*.md
 **/*.DS_Store
 .cache-loader
+*.development.js
+*.development.ts

--- a/packages/treats/alias.js
+++ b/packages/treats/alias.js
@@ -50,7 +50,14 @@ const CORE_PATH = path.resolve(__dirname),
     useTypescript = isTSFileExists(),
     //Filesystem hooks scan
     resolvedAlias = Object.keys(RESOLVER).reduce((accumulator, key) => {
-        if (process.env.NODE_ENV !== "test") {
+        if (
+            process.env.NODE_ENV === "development" &&
+            (key === "BUILD_ROUTE_PATH" || key === "BUILD_ROUTE_MODULE_PATH")
+        ) {
+            accumulator[`@@${key}@@`] = useTypescript
+                ? RESOLVER[key].developmentTypescript
+                : RESOLVER[key].development;
+        } else if (process.env.NODE_ENV !== "test") {
             accumulator[`@@${key}@@`] = selectPath(useTypescript, RESOLVER[key]);
         } else {
             accumulator[`@@${key}@@`] = RESOLVER[key].default;

--- a/packages/treats/package.json
+++ b/packages/treats/package.json
@@ -132,5 +132,8 @@
         "workbox-webpack-plugin": "4.1.0",
         "yargs": "12.0.1",
         "yarn-install": "1.0.0"
+    },
+    "devDependencies": {
+        "babel-plugin-transform-es2015-modules-commonjs": "6.26.2"
     }
 }

--- a/packages/treats/resolver.js
+++ b/packages/treats/resolver.js
@@ -1,7 +1,7 @@
 const path = require("path"),
     ROOT_PATH = process.cwd();
 
-/** 
+/**
  * Treats filesystem hooks with 3 config [custom, customTypescript, default].
  * custom or customTypescript will be used when you define them on your projects
  */
@@ -19,11 +19,15 @@ const RESOLVER = {
     BUILD_ROUTE_PATH: {
         custom: path.resolve(ROOT_PATH, "./src/_route/route.js"),
         customTypescript: path.resolve(ROOT_PATH, "./src/_route/route.ts"),
+        development: path.resolve(ROOT_PATH, "./src/_route/route.development.js"),
+        developmentTypescript: path.resolve(ROOT_PATH, "./src/_route/route.development.ts"),
         default: path.resolve(__dirname, "./default/_route/route.js")
     },
     BUILD_ROUTE_MODULE_PATH: {
         custom: path.resolve(ROOT_PATH, "./src/_route/module.js"),
         customTypescript: path.resolve(ROOT_PATH, "./src/_route/module.ts"),
+        development: path.resolve(ROOT_PATH, "./src/_route/module.development.js"),
+        developmentTypescript: path.resolve(ROOT_PATH, "./src/_route/module.development.ts"),
         default: path.resolve(__dirname, "./default/_route/module.js")
     },
     BUILD_SERVER_TEMPLATE_PATH: {

--- a/packages/treats/scripts/start
+++ b/packages/treats/scripts/start
@@ -13,6 +13,7 @@ const chalk = require("chalk"),
     checkTypescript = require("./util/checkTypescript"),
     generateTSConfig = require("./util/generateTSConfig"),
     isTSFileExists = require("./util/isTSFileExists"),
+    setupDevModules = require("./util/setup-dev-modules"),
     clean = require("./clean"),
     RESOLVER = require("../resolver"),
     WebpackDevServerUtils = require("react-dev-utils/WebpackDevServerUtils"),
@@ -143,6 +144,12 @@ const start = argv => {
     const useTypescript = isTSFileExists();
     checkTypescript(useTypescript);
 
+    //Setup routes & modules for development on-demand modules bundling
+    if ((!argv.env || argv.env === "development")) {
+        logger("log", "Generating on-demand modules");
+        setupDevModules(useTypescript, argv.module);
+    }
+
     getProcessForPort(userPort);
     WebpackDevServerUtils.choosePort("localhost", userPort).then(resolvedPort => {
         if(resolvedPort !== null) {
@@ -156,7 +163,11 @@ const start = argv => {
                 }
 
                 const entryFiles = Object.keys(RESOLVER).reduce((accumulator, key) => {
-                        const buildPath = useTypescript ? RESOLVER[key].customTypescript : RESOLVER[key].custom;
+                        let buildPath = useTypescript ? RESOLVER[key].customTypescript : RESOLVER[key].custom;
+                        if (process.env.NODE_ENV === "development" &&
+                            (key === "BUILD_ROUTE_PATH" || key === "BUILD_ROUTE_MODULE_PATH")) {
+                            buildPath = useTypescript ? RESOLVER[key].developmentTypescript : RESOLVER[key].development;
+                        }
                         accumulator.push(buildPath);
                         return accumulator;
                     }, []),

--- a/packages/treats/scripts/util/setup-dev-modules.js
+++ b/packages/treats/scripts/util/setup-dev-modules.js
@@ -1,0 +1,120 @@
+const fs = require("fs-extra"),
+    ROOT_PATH = process.cwd(),
+    path = require("path"),
+    alias = require("../../alias"),
+    logger = require("./logger"),
+    babel = require("@babel/core");
+
+/**
+ * Generate on-demand routes for development.
+ * @param {boolean} useTypescript is projects contain Typescript
+ * @param {string} modules user chosen modules
+ *
+ * @author Martino Christanto Khuangga
+ */
+const setupDevModules = (useTypescript, modules) => {
+    const routePath = alias["@@BUILD_ROUTE_PATH@@"],
+        appPaths = alias["@@BUILD_ROUTE_PATH@@"].replace("route.", "path."),
+        modulePath = alias["@@BUILD_ROUTE_MODULE_PATH@@"],
+        devRoutePath = path.resolve(
+            ROOT_PATH,
+            `./src/_route/route.development.${useTypescript ? "ts" : "js"}`
+        ),
+        devModulePath = path.resolve(
+            ROOT_PATH,
+            `./src/_route/module.development.${useTypescript ? "ts" : "js"}`
+        ),
+        onDemandModules = modules ? modules.split(",") : [];
+
+    //Write the whole files if user doesn't provide on-demand modules
+    if (onDemandModules.length === 0) {
+        fs.copyFileSync(routePath, devRoutePath);
+        fs.copyFileSync(modulePath, devModulePath);
+        return;
+    }
+
+    logger("log", `Transpiling _route/path.${useTypescript ? "ts" : "js"}`);
+
+    //Transpile _route/route.(js|ts) and _route/path(js|ts) to CommonJS
+    const routesCode = fs.readFileSync(routePath),
+        pathCode = fs.readFileSync(appPaths),
+        parsedRouteAst = babel.parse(routesCode),
+        parsedPathAst = babel.parse(pathCode),
+        { code: newPathCode } = babel.transformFromAstSync(parsedPathAst, pathCode, {
+            plugins: ["transform-es2015-modules-commonjs"]
+        });
+
+    logger(
+        "warn",
+        `Rewriting temporary _route/path.${useTypescript ? "ts" : "js"}. Do not stop the process`
+    );
+    fs.writeFileSync(appPaths, newPathCode);
+
+    const { code } = babel.transformFromAstSync(parsedRouteAst, routesCode, {
+        plugins: ["transform-es2015-modules-commonjs"]
+    });
+
+    logger("log", `Generating development on-demand routes: ${modules}`);
+    fs.writeFileSync(devRoutePath, code);
+
+    let finalRoutesContent = "",
+        finalModulesContent = "",
+        importedPathStrings = "";
+
+    const currentRoutes = require(devRoutePath).default,
+        finalRoutes = currentRoutes.filter(route => onDemandModules.indexOf(route.name) !== -1),
+        moduleObject = {},
+        modifiedRoutes = [];
+
+    //Generating required modules variable names
+    finalRoutes.forEach((route, index) => {
+        finalModulesContent += `import ${route.name.charAt(0).toUpperCase()}${route.name.slice(
+            1
+        )} from "@page/${route.name}";\n`;
+        moduleObject[`[${route.name.toUpperCase()}]`] = `${route.name
+            .charAt(0)
+            .toUpperCase()}${route.name.slice(1)}`;
+        importedPathStrings += `${route.name.toUpperCase()}${
+            index < finalRoutes.length - 1 ? ", " : ""
+        }`;
+
+        modifiedRoutes.push({
+            ...route,
+            path: route.name.toUpperCase()
+        });
+    });
+
+    finalModulesContent += `\nimport { ${importedPathStrings} } from "./path";\n\n`;
+    finalModulesContent += `const module = ${JSON.stringify(
+        moduleObject,
+        (key, value) => value,
+        4
+    ).replace(new RegExp("\"|'", "g"), "")}`;
+    finalModulesContent += "\n\nexport default module;\n";
+    fs.writeFileSync(devModulePath, finalModulesContent);
+
+    finalRoutesContent += `import { ${importedPathStrings} } from "./path";\n\n`;
+    finalRoutesContent += `const route = ${JSON.stringify(
+        modifiedRoutes,
+        (key, value) => {
+            if (key === "path") {
+                return `@@${value}@@`;
+            }
+            return value;
+        },
+        4
+    ).replace(new RegExp("\"@@|'@@|@@\"|@@'", "g"), "")};`;
+    finalRoutesContent += "\n\nexport default route;\n";
+
+    fs.writeFileSync(devRoutePath, finalRoutesContent);
+
+    logger(
+        "warn",
+        `Revert back _route/path.${useTypescript ? "ts" : "js"}. Do not stop the process`
+    );
+    fs.writeFileSync(appPaths, pathCode);
+
+    logger("debug", "On-demand routes generated!");
+};
+
+module.exports = setupDevModules;


### PR DESCRIPTION
Provide args when start the apps in development mode #1

command: `yarn start --module my_module1,my_module2`. 

Note:
1. Providing no arguments means we will build ALL modules.
2. This arguments will only works on development environment. 

PS: This script refer modules name from `src/_route/route.js` and to make this on-demand module bundling works you need to give module folder names (@page/<module_folder_name>) and variable names in `/src/_route/path.js` the same name as your defined modules name with the corresponding conventions (upper case for path variable names). See the examples below

example:
```
// src/_route/route.js
```
import { WELCOME, SECOND } from "./path";

const route = [
    {
        /** IMPORTANT: This name is the source of all conventions. 
         * Use it in arguments, as a folder name of your modules, and as your path variable names.
         */
        name: "welcome",
        path: WELCOME,
        exact: true,
        disabled: true
    },
    {
        name: "second",
        path: SECOND,
    },
];

export default route;
```
// src/_route/module.js
import Welcome from "@page/welcome"; //IMPORTANT: name your folder like this
import Second from "@page/second";

import { WELCOME, SECOND } from "./path";

const module = {
    [WELCOME]: Welcome,
    [SECOND]: Second
};

export default module;
```

```
// src/_route/path.js 
export const WELCOME = "/"; // IMPORTANT: name your variables with upper case like this
export const SECOND = "/second";
```

I would be open for any discussions! So please take time to review it