### PR TITLE
fix: change alias path

### DIFF
--- a/packages/eslint-config-treats/index.js
+++ b/packages/eslint-config-treats/index.js
@@ -1,6 +1,5 @@
 const path = require("path"),
-    ROOT_PATH = process.cwd(),
-    alias = require(path.join(ROOT_PATH, "./node_modules/treats/alias")),
+    alias = require(path.resolve(__dirname, "../treats/alias")),
     resolver = {
         map: Object.entries(alias),
         extensions: [".ts", ".js", ".jsx", ".json"]


### PR DESCRIPTION
Eslint failed to find `alias.js` file if we open the project in the editor from the outer folder.

Given this project structure:
```
projects
├── project A
│   ├── node_modules
│   │   ├── eslint-config-treats
│   │   ├── treats
```
alias returning `~/projects/node_modules/treats/alias` instead of `~/projects/project A/node_modules/treats/alias`.

Isn't it better to find the file relative to its package folder?